### PR TITLE
Activity refactor

### DIFF
--- a/src/ActivityImporter.Engine/Graph/GraphImporter.cs
+++ b/src/ActivityImporter.Engine/Graph/GraphImporter.cs
@@ -1,6 +1,6 @@
 ﻿using ActivityImporter.Engine.Graph.GraphUser;
 using ActivityImporter.Engine.Graph.O365UsageReports.Models;
-using ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders.ActivityLoaders;
+using ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders;
 using Common.DataUtils;
 using Common.Engine.Config;
 using Entities.DB;

--- a/src/ActivityImporter.Engine/Graph/GraphImporter.cs
+++ b/src/ActivityImporter.Engine/Graph/GraphImporter.cs
@@ -1,4 +1,5 @@
 ﻿using ActivityImporter.Engine.Graph.GraphUser;
+using ActivityImporter.Engine.Graph.O365UsageReports;
 using ActivityImporter.Engine.Graph.O365UsageReports.Models;
 using ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders;
 using Common.DataUtils;
@@ -72,14 +73,14 @@ public class GraphImporter : AbstractApiLoader
             usageActivityTimer.Start();
 
             // Global user activity report. Each thread creates own context.
-            await GetAndSaveActivityReportsMultiThreaded(DAYS_BACK, httpClient);
+            await GetAndSaveActivityReportsMultiThreaded(DAYS_BACK, new GraphActivityLoader(httpClient, _telemetry));
 
             // Track finished event 
             usageActivityTimer.TrackFinishedEventAndStopTimer(AnalyticsEvent.FinishedSectionImport);
         }
     }
 
-    public async Task GetAndSaveActivityReportsMultiThreaded(int daysBackMax, ManualGraphCallClient client)
+    public async Task GetAndSaveActivityReportsMultiThreaded(int daysBackMax, IUserActivityLoader loader)
     {
         _telemetry.LogInformation($"Reading all activity reports from {daysBackMax} days back...");
 
@@ -88,36 +89,75 @@ public class GraphImporter : AbstractApiLoader
 
         var lookupIdCache = new ConcurrentLookupDbIdsCache();
 
-        importTasks.Add(LoadAndSaveReportAsync(new TeamsUserUsageLoader(client, _telemetry), daysBackMax, 
+        using var dbTeamsUserUsageLoader = GetDB();
+        var sqlAdaptorTeamsUserUsageLoader = new SqlUsageReportPersistence(lookupIdCache, dbTeamsUserUsageLoader, new Entities.DB.LookupCaches.Discrete.UserCache(dbTeamsUserUsageLoader), _telemetry);
+        importTasks.Add(LoadAndSaveReportAsync(new TeamsUserUsageLoader(loader, sqlAdaptorTeamsUserUsageLoader, _telemetry), daysBackMax, 
             "Teams user activity", _telemetry, lookupIdCache));
-        importTasks.Add(LoadAndSaveReportAsync(new OutlookUserActivityLoader(client, _telemetry), daysBackMax, 
+
+        using var dbOutlookUserActivityLoader = GetDB();
+        var sqlAdaptorOutlookUserActivityLoader = new SqlUsageReportPersistence(lookupIdCache, dbOutlookUserActivityLoader, new Entities.DB.LookupCaches.Discrete.UserCache(dbOutlookUserActivityLoader), _telemetry);
+        importTasks.Add(LoadAndSaveReportAsync(new OutlookUserActivityLoader(loader, sqlAdaptorOutlookUserActivityLoader, _telemetry), daysBackMax,
             "Outlook activity", _telemetry, lookupIdCache));
-        importTasks.Add(LoadAndSaveReportAsync(new OneDriveUserActivityLoader(client, _telemetry), daysBackMax, 
+
+
+        using var dbOneDriveUserActivityLoader = GetDB();
+        var sqlAdaptorOneDriveUserActivityLoader = new SqlUsageReportPersistence(lookupIdCache, dbOneDriveUserActivityLoader, new Entities.DB.LookupCaches.Discrete.UserCache(dbOneDriveUserActivityLoader), _telemetry);
+        importTasks.Add(LoadAndSaveReportAsync(new TeamsUserUsageLoader(loader, sqlAdaptorOneDriveUserActivityLoader, _telemetry), daysBackMax,
             "OneDrive activity", _telemetry, lookupIdCache));
-        importTasks.Add(LoadAndSaveReportAsync(new SharePointUserActivityLoader(client, _telemetry), daysBackMax, 
+
+        using var dbSharePointUserActivityLoader = GetDB();
+        var sqlAdaptorSharePointUserActivityLoader = new SqlUsageReportPersistence(lookupIdCache, dbSharePointUserActivityLoader, new Entities.DB.LookupCaches.Discrete.UserCache(dbSharePointUserActivityLoader), _telemetry);
+        importTasks.Add(LoadAndSaveReportAsync(new SharePointUserActivityLoader(loader, sqlAdaptorSharePointUserActivityLoader, _telemetry), daysBackMax,
             "SharePoint user activity", _telemetry, lookupIdCache));
-        importTasks.Add(LoadAndSaveReportAsync(new TeamsUserDeviceLoader(client, _telemetry), daysBackMax,
+
+
+        using var dbTeamsUserDeviceLoader = GetDB();
+        var sqlAdaptorTeamsUserDeviceLoader = new SqlUsageReportPersistence(lookupIdCache, dbTeamsUserDeviceLoader, new Entities.DB.LookupCaches.Discrete.UserCache(dbTeamsUserDeviceLoader), _telemetry);
+        importTasks.Add(LoadAndSaveReportAsync(new TeamsUserDeviceLoader(loader, sqlAdaptorTeamsUserDeviceLoader, _telemetry), daysBackMax,
             "Teams user device activity", _telemetry, lookupIdCache));
-        importTasks.Add(LoadAndSaveReportAsync(new AppPlatformUserActivityLoader(client, _telemetry), daysBackMax, 
+
+
+        using var dbAppPlatformUserActivityLoader = GetDB();
+        var sqlAdaptorAppPlatformUserActivityLoader = new SqlUsageReportPersistence(lookupIdCache, dbAppPlatformUserActivityLoader, new Entities.DB.LookupCaches.Discrete.UserCache(dbAppPlatformUserActivityLoader), _telemetry);
+        importTasks.Add(LoadAndSaveReportAsync(new AppPlatformUserActivityLoader(loader, sqlAdaptorAppPlatformUserActivityLoader, _telemetry), daysBackMax,
             "App platform activity", _telemetry, lookupIdCache));
-        importTasks.Add(LoadAndSaveReportAsync(new YammerUserUsageLoader(client, _telemetry), daysBackMax, 
+
+        using var dbYammerUserUsageLoader = GetDB();
+        var sqlAdaptorYammerUserUsageLoader = new SqlUsageReportPersistence(lookupIdCache, dbYammerUserUsageLoader, new Entities.DB.LookupCaches.Discrete.UserCache(dbYammerUserUsageLoader), _telemetry);
+        importTasks.Add(LoadAndSaveReportAsync(new YammerUserUsageLoader(loader, sqlAdaptorYammerUserUsageLoader, _telemetry), daysBackMax,
             "Yammer user activity", _telemetry, lookupIdCache));
-        importTasks.Add(LoadAndSaveReportAsync(new YammerDeviceUsageLoader(client, _telemetry), daysBackMax, 
+
+        using var dbYammerDeviceUsageLoader = GetDB();
+        var sqlAdaptor = new SqlUsageReportPersistence(lookupIdCache, dbYammerDeviceUsageLoader, new Entities.DB.LookupCaches.Discrete.UserCache(dbYammerDeviceUsageLoader), _telemetry);
+        importTasks.Add(LoadAndSaveReportAsync(new YammerDeviceUsageLoader(loader, sqlAdaptor, _telemetry), daysBackMax,
             "Yammer device activity", _telemetry, lookupIdCache));
+        
 
         await Task.WhenAll(importTasks);
 
         _telemetry.LogInformation($"Activity reports imported.");
     }
 
+    DataContext GetDB()
+    {
+        
+        var optionsBuilder = new DbContextOptionsBuilder<DataContext>();
+        optionsBuilder.UseSqlServer(_appConfig.ConnectionStrings.SQL);
+
+        return new DataContext(optionsBuilder.Options);
+        
+    }
+
     async Task<int> LoadAndSaveReportAsync<TReportDbType, TUserActivityUserDetail>
-        (AbstractActivityLoader<TReportDbType, TUserActivityUserDetail> abstractActivityLoader,
-        int daysBackMax, string thingWeAreImporting, ILogger telemetry, ConcurrentLookupDbIdsCache userEmailToDbIdCache)
-        where TReportDbType : AbstractUsageActivityLog, new()
+        (AbstractActivityLoader<TReportDbType, TUserActivityUserDetail> abstractActivityLoader, 
+        int daysBackMax, string thingWeAreImporting, ILogger telemetry, ConcurrentLookupDbIdsCache userEmailToDbIdCache
+        )
+            where TReportDbType : AbstractUsageActivityLog, new()
     where TUserActivityUserDetail : AbstractActivityRecord
     {
         telemetry.LogInformation($"Importing {thingWeAreImporting} reports...");
-        await abstractActivityLoader.PopulateLoadedReportPagesFromGraph(daysBackMax);
+
+       await abstractActivityLoader.PopulateLoadedReportPagesFromGraph(daysBackMax);
 
         var optionsBuilder = new DbContextOptionsBuilder<DataContext>();
         optionsBuilder.UseSqlServer(_appConfig.ConnectionStrings.SQL);

--- a/src/ActivityImporter.Engine/Graph/GraphImporter.cs
+++ b/src/ActivityImporter.Engine/Graph/GraphImporter.cs
@@ -91,47 +91,47 @@ public class GraphImporter : AbstractApiLoader
 
         using var dbTeamsUserUsageLoader = GetDB();
         var sqlAdaptorTeamsUserUsageLoader = new SqlUsageReportPersistence(lookupIdCache, dbTeamsUserUsageLoader, new Entities.DB.LookupCaches.Discrete.UserCache(dbTeamsUserUsageLoader), _telemetry);
-        importTasks.Add(LoadAndSaveReportAsync(new TeamsUserUsageLoader(loader, sqlAdaptorTeamsUserUsageLoader, _telemetry), daysBackMax, 
-            "Teams user activity", _telemetry, lookupIdCache));
+        importTasks.Add(LoadAndSaveReportAsync(new TeamsUserUsageLoader(loader, sqlAdaptorTeamsUserUsageLoader, _telemetry), daysBackMax,
+            "Teams user activity"));
 
         using var dbOutlookUserActivityLoader = GetDB();
         var sqlAdaptorOutlookUserActivityLoader = new SqlUsageReportPersistence(lookupIdCache, dbOutlookUserActivityLoader, new Entities.DB.LookupCaches.Discrete.UserCache(dbOutlookUserActivityLoader), _telemetry);
         importTasks.Add(LoadAndSaveReportAsync(new OutlookUserActivityLoader(loader, sqlAdaptorOutlookUserActivityLoader, _telemetry), daysBackMax,
-            "Outlook activity", _telemetry, lookupIdCache));
+            "Outlook activity"));
 
 
         using var dbOneDriveUserActivityLoader = GetDB();
         var sqlAdaptorOneDriveUserActivityLoader = new SqlUsageReportPersistence(lookupIdCache, dbOneDriveUserActivityLoader, new Entities.DB.LookupCaches.Discrete.UserCache(dbOneDriveUserActivityLoader), _telemetry);
         importTasks.Add(LoadAndSaveReportAsync(new TeamsUserUsageLoader(loader, sqlAdaptorOneDriveUserActivityLoader, _telemetry), daysBackMax,
-            "OneDrive activity", _telemetry, lookupIdCache));
+            "OneDrive activity"));
 
         using var dbSharePointUserActivityLoader = GetDB();
         var sqlAdaptorSharePointUserActivityLoader = new SqlUsageReportPersistence(lookupIdCache, dbSharePointUserActivityLoader, new Entities.DB.LookupCaches.Discrete.UserCache(dbSharePointUserActivityLoader), _telemetry);
         importTasks.Add(LoadAndSaveReportAsync(new SharePointUserActivityLoader(loader, sqlAdaptorSharePointUserActivityLoader, _telemetry), daysBackMax,
-            "SharePoint user activity", _telemetry, lookupIdCache));
+            "SharePoint user activity"));
 
 
         using var dbTeamsUserDeviceLoader = GetDB();
         var sqlAdaptorTeamsUserDeviceLoader = new SqlUsageReportPersistence(lookupIdCache, dbTeamsUserDeviceLoader, new Entities.DB.LookupCaches.Discrete.UserCache(dbTeamsUserDeviceLoader), _telemetry);
         importTasks.Add(LoadAndSaveReportAsync(new TeamsUserDeviceLoader(loader, sqlAdaptorTeamsUserDeviceLoader, _telemetry), daysBackMax,
-            "Teams user device activity", _telemetry, lookupIdCache));
+            "Teams user device activity"));
 
 
         using var dbAppPlatformUserActivityLoader = GetDB();
         var sqlAdaptorAppPlatformUserActivityLoader = new SqlUsageReportPersistence(lookupIdCache, dbAppPlatformUserActivityLoader, new Entities.DB.LookupCaches.Discrete.UserCache(dbAppPlatformUserActivityLoader), _telemetry);
         importTasks.Add(LoadAndSaveReportAsync(new AppPlatformUserActivityLoader(loader, sqlAdaptorAppPlatformUserActivityLoader, _telemetry), daysBackMax,
-            "App platform activity", _telemetry, lookupIdCache));
+            "App platform activity"));
 
         using var dbYammerUserUsageLoader = GetDB();
         var sqlAdaptorYammerUserUsageLoader = new SqlUsageReportPersistence(lookupIdCache, dbYammerUserUsageLoader, new Entities.DB.LookupCaches.Discrete.UserCache(dbYammerUserUsageLoader), _telemetry);
         importTasks.Add(LoadAndSaveReportAsync(new YammerUserUsageLoader(loader, sqlAdaptorYammerUserUsageLoader, _telemetry), daysBackMax,
-            "Yammer user activity", _telemetry, lookupIdCache));
+            "Yammer user activity"));
 
         using var dbYammerDeviceUsageLoader = GetDB();
         var sqlAdaptor = new SqlUsageReportPersistence(lookupIdCache, dbYammerDeviceUsageLoader, new Entities.DB.LookupCaches.Discrete.UserCache(dbYammerDeviceUsageLoader), _telemetry);
         importTasks.Add(LoadAndSaveReportAsync(new YammerDeviceUsageLoader(loader, sqlAdaptor, _telemetry), daysBackMax,
-            "Yammer device activity", _telemetry, lookupIdCache));
-        
+            "Yammer device activity"));
+
 
         await Task.WhenAll(importTasks);
 
@@ -140,24 +140,24 @@ public class GraphImporter : AbstractApiLoader
 
     DataContext GetDB()
     {
-        
+
         var optionsBuilder = new DbContextOptionsBuilder<DataContext>();
         optionsBuilder.UseSqlServer(_appConfig.ConnectionStrings.SQL);
 
         return new DataContext(optionsBuilder.Options);
-        
+
     }
 
     async Task<int> LoadAndSaveReportAsync<TReportDbType, TUserActivityUserDetail>
-        (AbstractActivityLoader<TReportDbType, TUserActivityUserDetail> abstractActivityLoader, 
-        int daysBackMax, string thingWeAreImporting, ILogger telemetry, ConcurrentLookupDbIdsCache userEmailToDbIdCache
+        (AbstractActivityLoader<TReportDbType, TUserActivityUserDetail> abstractActivityLoader,
+        int daysBackMax, string thingWeAreImporting
         )
             where TReportDbType : AbstractUsageActivityLog, new()
     where TUserActivityUserDetail : AbstractActivityRecord
     {
-        telemetry.LogInformation($"Importing {thingWeAreImporting} reports...");
+        _telemetry.LogInformation($"Importing {thingWeAreImporting} reports...");
 
-       await abstractActivityLoader.PopulateLoadedReportPagesFromGraph(daysBackMax);
+        await abstractActivityLoader.PopulateLoadedReportPagesFromGraph(daysBackMax);
 
         var optionsBuilder = new DbContextOptionsBuilder<DataContext>();
         optionsBuilder.UseSqlServer(_appConfig.ConnectionStrings.SQL);
@@ -165,11 +165,11 @@ public class GraphImporter : AbstractApiLoader
         using (var db = new DataContext(optionsBuilder.Options))
         {
             _telemetry.LogInformation($"Read {abstractActivityLoader.LoadedReportPages.SelectMany(p => p.Value).Count().ToString("N0")} {thingWeAreImporting} records from Graph API");
-            await abstractActivityLoader.SaveLoadedReportsToSql(userEmailToDbIdCache, db, new Entities.DB.LookupCaches.Discrete.UserCache(db));
+            await abstractActivityLoader.SaveLoadedReports();
         }
 
         var total = abstractActivityLoader.LoadedReportPages.SelectMany(r => r.Value).Count();
-        telemetry.LogInformation($"Imported {total.ToString("N0")} {thingWeAreImporting} reports.");
+        _telemetry.LogInformation($"Imported {total.ToString("N0")} {thingWeAreImporting} reports.");
 
         return total;
     }

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/IUsageReportPersistence.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/IUsageReportPersistence.cs
@@ -1,11 +1,15 @@
 ﻿using ActivityImporter.Engine.Graph.O365UsageReports.Models;
 using ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders;
 using Entities.DB.Entities;
+using Microsoft.EntityFrameworkCore;
 
 namespace ActivityImporter.Engine.Graph.O365UsageReports;
 
 public interface IUsageReportPersistence
 {
+    Task<DateTime?> GetLastActivity<TReportDbType, TAbstractActivityRecord>(AbstractActivityLoader<TReportDbType, TAbstractActivityRecord> loader, string forUPN)
+        where TReportDbType : AbstractUsageActivityLog, new()
+        where TAbstractActivityRecord : AbstractActivityRecord;
     Task SaveLoadedReports<TReportDbType, TAbstractActivityRecord>(Dictionary<DateTime, List<TAbstractActivityRecord>> reportPages, AbstractActivityLoader<TReportDbType, TAbstractActivityRecord> loader)
         where TReportDbType : AbstractUsageActivityLog, new()
         where TAbstractActivityRecord : AbstractActivityRecord;

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/IUsageReportPersistence.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/IUsageReportPersistence.cs
@@ -6,7 +6,7 @@ namespace ActivityImporter.Engine.Graph.O365UsageReports;
 
 public interface IUsageReportPersistence
 {
-    Task<DateTime?> GetLastActivityForAllUsers<TReportDbType, TAbstractActivityRecord>(AbstractActivityLoader<TReportDbType, TAbstractActivityRecord> loader)
+    Task<DateTime?> GetOldestActivityDateForAllUsers<TReportDbType, TAbstractActivityRecord>(AbstractActivityLoader<TReportDbType, TAbstractActivityRecord> loader)
         where TReportDbType : AbstractUsageActivityLog, new()
         where TAbstractActivityRecord : AbstractActivityRecord;
     Task SaveLoadedReports<TReportDbType, TAbstractActivityRecord>(Dictionary<DateTime, List<TAbstractActivityRecord>> reportPages, AbstractActivityLoader<TReportDbType, TAbstractActivityRecord> loader)

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/IUsageReportPersistence.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/IUsageReportPersistence.cs
@@ -1,13 +1,12 @@
 ﻿using ActivityImporter.Engine.Graph.O365UsageReports.Models;
 using ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders;
 using Entities.DB.Entities;
-using Microsoft.EntityFrameworkCore;
 
 namespace ActivityImporter.Engine.Graph.O365UsageReports;
 
 public interface IUsageReportPersistence
 {
-    Task<DateTime?> GetLastActivity<TReportDbType, TAbstractActivityRecord>(AbstractActivityLoader<TReportDbType, TAbstractActivityRecord> loader, string forUPN)
+    Task<DateTime?> GetLastActivityForAllUsers<TReportDbType, TAbstractActivityRecord>(AbstractActivityLoader<TReportDbType, TAbstractActivityRecord> loader)
         where TReportDbType : AbstractUsageActivityLog, new()
         where TAbstractActivityRecord : AbstractActivityRecord;
     Task SaveLoadedReports<TReportDbType, TAbstractActivityRecord>(Dictionary<DateTime, List<TAbstractActivityRecord>> reportPages, AbstractActivityLoader<TReportDbType, TAbstractActivityRecord> loader)

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/IUsageReportPersistence.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/IUsageReportPersistence.cs
@@ -1,0 +1,12 @@
+﻿using ActivityImporter.Engine.Graph.O365UsageReports.Models;
+using ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders;
+using Entities.DB.Entities;
+
+namespace ActivityImporter.Engine.Graph.O365UsageReports;
+
+public interface IUsageReportPersistence
+{
+    Task SaveLoadedReports<TReportDbType, TAbstractActivityRecord>(Dictionary<DateTime, List<TAbstractActivityRecord>> reportPages, AbstractActivityLoader<TReportDbType, TAbstractActivityRecord> loader)
+        where TReportDbType : AbstractUsageActivityLog, new()
+        where TAbstractActivityRecord : AbstractActivityRecord;
+}

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/Interfaces.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/Interfaces.cs
@@ -1,0 +1,14 @@
+﻿using ActivityImporter.Engine.Graph.O365UsageReports.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ActivityImporter.Engine.Graph.O365UsageReports;
+
+
+public interface IUserActivityLoader
+{
+    Task<List<TAbstractActivityRecord>> LoadReport<TAbstractActivityRecord>(DateTime dt, string reportGraphURL) where TAbstractActivityRecord : AbstractActivityRecord;
+}

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/Models/AppPlatformUserActivityDetail.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/Models/AppPlatformUserActivityDetail.cs
@@ -9,7 +9,7 @@ namespace ActivityImporter.Engine.Graph.O365UsageReports.Models;
 public class AppPlatformUserActivityDetail : AbstractUserActivityUserRecordWithUpn
 {
     [JsonProperty("details")]
-    public List<AppPlatformUserActivityDetailItems> Details { get; set; }
+    public List<AppPlatformUserActivityDetailItems> Details { get; set; } = new();
 }
 
 public class AppPlatformUserActivityDetailItems

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/Models/AppPlatformUserActivityDetail.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/Models/AppPlatformUserActivityDetail.cs
@@ -5,6 +5,7 @@ namespace ActivityImporter.Engine.Graph.O365UsageReports.Models;
 
 /// <summary>
 /// https://learn.microsoft.com/en-us/graph/api/reportroot-getm365appuserdetail?view=graph-rest-beta
+/// For some reason this report has a different structure than the others.
 /// </summary>
 public class AppPlatformUserActivityDetail : AbstractUserActivityUserRecordWithUpn
 {

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/Models/OneDriveUserActivityRecord.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/Models/OneDriveUserActivityRecord.cs
@@ -1,24 +1,19 @@
 ﻿using Newtonsoft.Json;
 
-namespace ActivityImporter.Engine.Graph.O365UsageReports.Models
+namespace ActivityImporter.Engine.Graph.O365UsageReports.Models;
+
+public class OneDriveUserActivityRecord : AbstractUserActivityUserRecordWithUpn
 {
-    public class OneDriveUserActivityRecord : AbstractUserActivityUserRecordWithUpn
-    {
 
-        [JsonProperty("viewedOrEditedFileCount")]
-        public int ViewedOrEdited { get; set; }
+    [JsonProperty("viewedOrEditedFileCount")]
+    public int ViewedOrEdited { get; set; }
 
-        [JsonProperty("syncedFileCount")]
-        public int Synced { get; set; }
+    [JsonProperty("syncedFileCount")]
+    public int Synced { get; set; }
 
-        [JsonProperty("sharedInternallyFileCount")]
-        public int SharedInternally { get; set; }
+    [JsonProperty("sharedInternallyFileCount")]
+    public int SharedInternally { get; set; }
 
-        [JsonProperty("sharedExternallyFileCount")]
-        public int SharedExternally { get; set; }
-
-        [JsonProperty("lastActivityDate")]
-        public DateTime LastActivityDate { get; set; }
-    }
-
+    [JsonProperty("sharedExternallyFileCount")]
+    public int SharedExternally { get; set; }
 }

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/Models/OutlookUserActivityUserRecord.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/Models/OutlookUserActivityUserRecord.cs
@@ -1,26 +1,24 @@
 ﻿using Newtonsoft.Json;
 
-namespace ActivityImporter.Engine.Graph.O365UsageReports.Models
+namespace ActivityImporter.Engine.Graph.O365UsageReports.Models;
+
+public class OutlookUserActivityUserRecord : AbstractUserActivityUserRecordWithUpn
 {
-    public class OutlookUserActivityUserRecord : AbstractUserActivityUserRecordWithUpn
-    {
 
-        [JsonProperty("sendCount")]
-        public int SendCount { get; set; }
+    [JsonProperty("sendCount")]
+    public int SendCount { get; set; }
 
 
-        [JsonProperty("receiveCount")]
-        public int ReceiveCount { get; set; }
+    [JsonProperty("receiveCount")]
+    public int ReceiveCount { get; set; }
 
 
-        [JsonProperty("readCount")]
-        public int ReadCount { get; set; }
+    [JsonProperty("readCount")]
+    public int ReadCount { get; set; }
 
-        [JsonProperty("meetingCreatedCount")]
-        public int MeetingCreated { get; set; }
+    [JsonProperty("meetingCreatedCount")]
+    public int MeetingCreated { get; set; }
 
-        [JsonProperty("meetingInteractedCount")]
-        public int MeetingInteracted { get; set; }
-    }
-
+    [JsonProperty("meetingInteractedCount")]
+    public int MeetingInteracted { get; set; }
 }

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/Models/SharePointUserActivityRecord.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/Models/SharePointUserActivityRecord.cs
@@ -1,24 +1,22 @@
 ﻿using Newtonsoft.Json;
 
-namespace ActivityImporter.Engine.Graph.O365UsageReports.Models
+namespace ActivityImporter.Engine.Graph.O365UsageReports.Models;
+
+public class SharePointUserActivityRecord : AbstractUserActivityUserRecordWithUpn
 {
-    public class SharePointUserActivityRecord : AbstractUserActivityUserRecordWithUpn
-    {
 
-        [JsonProperty("viewedOrEditedFileCount")]
-        public int ViewedOrEdited { get; set; }
+    [JsonProperty("viewedOrEditedFileCount")]
+    public int ViewedOrEdited { get; set; }
 
-        [JsonProperty("syncedFileCount")]
-        public int Synced { get; set; }
+    [JsonProperty("syncedFileCount")]
+    public int Synced { get; set; }
 
-        [JsonProperty("sharedInternallyFileCount")]
-        public int SharedInternally { get; set; }
+    [JsonProperty("sharedInternallyFileCount")]
+    public int SharedInternally { get; set; }
 
-        [JsonProperty("sharedExternallyFileCount")]
-        public int SharedExternally { get; set; }
+    [JsonProperty("sharedExternallyFileCount")]
+    public int SharedExternally { get; set; }
 
-        [JsonProperty("lastActivityDate")]
-        public DateTime LastActivityDate { get; set; }
-    }
-
+    [JsonProperty("lastActivityDate")]
+    public DateTime LastActivityDate { get; set; }
 }

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/Models/TeamsDeviceUsageUserDetail.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/Models/TeamsDeviceUsageUserDetail.cs
@@ -8,21 +8,12 @@ namespace ActivityImporter.Engine.Graph.O365UsageReports.Models;
 /// </summary>
 public class TeamsDeviceUsageUserDetail : AbstractUserActivityUserRecordWithUpn
 {
-    [JsonProperty("reportRefreshDate")]
-    public string ReportRefreshDate { get; set; }
-
-
     [JsonProperty("isLicensed")]
     public bool? IsLicensed { get; set; }
 
-    [JsonProperty("lastActivityDate")]
-    public string LastActivityDate { get; set; }
 
     [JsonProperty("isDeleted")]
     public bool? IsDeleted { get; set; }
-
-    [JsonProperty("deletedDate")]
-    public string DeletedDate { get; set; }
 
     [JsonProperty("usedWeb")]
     public bool? UsedWeb { get; set; }
@@ -48,6 +39,4 @@ public class TeamsDeviceUsageUserDetail : AbstractUserActivityUserRecordWithUpn
     [JsonProperty("usedLinux")]
     public bool? UsedLinux { get; set; }
 
-    [JsonProperty("reportPeriod")]
-    public string ReportPeriod { get; set; }
 }

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/Models/TeamsDeviceUsageUserDetail.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/Models/TeamsDeviceUsageUserDetail.cs
@@ -8,12 +8,6 @@ namespace ActivityImporter.Engine.Graph.O365UsageReports.Models;
 /// </summary>
 public class TeamsDeviceUsageUserDetail : AbstractUserActivityUserRecordWithUpn
 {
-    [JsonProperty("isLicensed")]
-    public bool? IsLicensed { get; set; }
-
-
-    [JsonProperty("isDeleted")]
-    public bool? IsDeleted { get; set; }
 
     [JsonProperty("usedWeb")]
     public bool? UsedWeb { get; set; }

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/Models/TeamsUserActivityUserRecord.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/Models/TeamsUserActivityUserRecord.cs
@@ -4,12 +4,6 @@ namespace ActivityImporter.Engine.Graph.O365UsageReports.Models;
 
 public class TeamsUserActivityUserRecord : AbstractUserActivityUserRecordWithUpn
 {
-    [JsonProperty("deletedDate")]
-    public string DeletedDate { get; set; } = null!;
-
-    [JsonProperty("assignedProducts")]
-    public string[] AssignedProducts { get; set; } = new string[] { };
-
     [JsonProperty("teamChatMessageCount")]
     public int TeamChatMessageCount { get; set; }
 

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/AbstractActivityLoader.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/AbstractActivityLoader.cs
@@ -35,7 +35,7 @@ public abstract class AbstractActivityLoader<TReportDbType, TAbstractActivityRec
         var pages = new Dictionary<DateTime, List<TAbstractActivityRecord>>();
 
         var daysBackMax = MAX_DAYS_BACK;       // Docs say 30, but in reality it's 28 https://learn.microsoft.com/en-us/graph/api/reportroot-getm365appuserdetail?view=graph-rest-1.0&tabs=http#function-parameters
-        var latestActivityAllUsers = await _usageReportPersistence.GetLastActivityForAllUsers(this);
+        var latestActivityAllUsers = await _usageReportPersistence.GetOldestActivityDateForAllUsers(this);
         if (latestActivityAllUsers != null)
         {
             _telemetry.LogInformation($"Last activity for all users for {this.DataContextPropertyName}: {latestActivityAllUsers.Value.ToGraphDateString()}");

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/AbstractActivityLoader.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/AbstractActivityLoader.cs
@@ -6,7 +6,7 @@ using Entities.DB.LookupCaches.Discrete;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
-namespace ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders.ActivityLoaders;
+namespace ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders;
 
 
 /// <summary>
@@ -23,8 +23,8 @@ public abstract class AbstractActivityLoader<TReportDbType, TAbstractActivityRec
 
     internal AbstractActivityLoader(ManualGraphCallClient client, ILogger telemetry)
     {
-        this._client = client;
-        this.Telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
+        _client = client;
+        Telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
     }
 
     #region Props
@@ -52,7 +52,7 @@ public abstract class AbstractActivityLoader<TReportDbType, TAbstractActivityRec
             var daysBack = (daysBackIdx + 1) * -1;
             var dt = DateTime.Now.AddDays(daysBack);
 
-            Telemetry.LogInformation($"Loading {this.GetType().Name} for date {dt.ToString("dd-MM-yyyy")}");
+            Telemetry.LogInformation($"Loading {GetType().Name} for date {dt.ToString("dd-MM-yyyy")}");
 
             var requestUrl = $"{ReportGraphURL}(date={dt.ToString("yyyy-MM-dd")})?$format=application/json";
             var dayReports = await _client.LoadAllPagesWithThrottleRetries<TAbstractActivityRecord>(requestUrl, Telemetry);
@@ -127,7 +127,7 @@ public abstract class AbstractActivityLoader<TReportDbType, TAbstractActivityRec
                 // Output progress every 1000 imports
                 if (i > 0 && i % 1000 == 0)
                 {
-                    Console.WriteLine($"{this.GetType().Name}: Saved {i} / {LoadedReportPages.SelectMany(r => r.Value).Count()}");
+                    Console.WriteLine($"{GetType().Name}: Saved {i} / {LoadedReportPages.SelectMany(r => r.Value).Count()}");
                 }
 
                 // Create new log if necesary

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/AbstractActivityLoader.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/AbstractActivityLoader.cs
@@ -35,11 +35,15 @@ public abstract class AbstractActivityLoader<TReportDbType, TAbstractActivityRec
         var pages = new Dictionary<DateTime, List<TAbstractActivityRecord>>();
 
         var daysBackMax = MAX_DAYS_BACK;       // Docs say 30, but in reality it's 28 https://learn.microsoft.com/en-us/graph/api/reportroot-getm365appuserdetail?view=graph-rest-1.0&tabs=http#function-parameters
-        var latestActivityAllUsers = await _usageReportPersistence.GetOldestActivityDateForAllUsers(this);
-        if (latestActivityAllUsers != null)
+        var oldestActivityDate = await _usageReportPersistence.GetOldestActivityDateForAllUsers(this);
+        if (oldestActivityDate != null)
         {
-            _telemetry.LogInformation($"Last activity for all users for {this.DataContextPropertyName}: {latestActivityAllUsers.Value.ToGraphDateString()}");
-            daysBackMax = (DateTime.Now - latestActivityAllUsers.Value).Days;
+            daysBackMax = (DateTime.Now - oldestActivityDate.Value).Days;
+            if (daysBackMax > MAX_DAYS_BACK)
+            {
+                daysBackMax = MAX_DAYS_BACK;
+            }
+            _telemetry.LogInformation($"Last activity for all users for {this.DataContextPropertyName}: {oldestActivityDate.Value.ToGraphDateString()}. Reading {daysBackMax} days back");
         }
         else
         {

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/AppPlatformUserActivityLoader.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/AppPlatformUserActivityLoader.cs
@@ -1,7 +1,6 @@
 ﻿using ActivityImporter.Engine.Graph.O365UsageReports.Models;
 using Entities.DB;
 using Entities.DB.Entities.UsageReports;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
 namespace ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders;

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/AppPlatformUserActivityLoader.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/AppPlatformUserActivityLoader.cs
@@ -10,14 +10,14 @@ namespace ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders;
 // https://learn.microsoft.com/en-us/graph/api/reportroot-getm365appuserdetail?view=graph-rest-beta
 public class AppPlatformUserActivityLoader : AbstractActivityLoader<AppPlatformUserActivityLog, AppPlatformUserActivityDetail>
 {
-    public AppPlatformUserActivityLoader(ManualGraphCallClient client, ILogger telemetry)
-        : base(client, telemetry)
+    public AppPlatformUserActivityLoader(IUserActivityLoader activityLoader, IUsageReportPersistence usageReportPersistence, ILogger telemetry)
+        : base(activityLoader, usageReportPersistence, telemetry)
     {
     }
 
-    public override string ReportGraphURL => "https://graph.microsoft.com/v1.0/reports/getM365AppUserDetail";
+    public override string ReportGraphURL => "https://graph.microsoft.com/beta/reports/getM365AppUserDetail";
 
-    protected override void PopulateReportSpecificMetadata(AppPlatformUserActivityLog dateRequestedLog, AppPlatformUserActivityDetail reportPage)
+    public override void PopulateReportSpecificMetadata(AppPlatformUserActivityLog dateRequestedLog, AppPlatformUserActivityDetail reportPage)
     {
         if (reportPage.Details.Count != 1)
         {

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/AppPlatformUserActivityLoader.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/AppPlatformUserActivityLoader.cs
@@ -122,5 +122,5 @@ public class AppPlatformUserActivityLoader : AbstractActivityLoader<AppPlatformU
 
         return count;
     }
-    public override DbSet<AppPlatformUserActivityLog> GetTable(DataContext context) => context.AppPlatformUserUsageLog;
+    public override string DataContextPropertyName => nameof(DataContext.AppPlatformUserUsageLog);
 }

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/AppPlatformUserActivityLoader.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/AppPlatformUserActivityLoader.cs
@@ -4,7 +4,7 @@ using Entities.DB.Entities.UsageReports;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
-namespace ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders.ActivityLoaders;
+namespace ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders;
 
 
 // https://learn.microsoft.com/en-us/graph/api/reportroot-getm365appuserdetail?view=graph-rest-beta
@@ -15,7 +15,7 @@ public class AppPlatformUserActivityLoader : AbstractActivityLoader<AppPlatformU
     {
     }
 
-    public override string ReportGraphURL => "https://graph.microsoft.com/beta/reports/getM365AppUserDetail";
+    public override string ReportGraphURL => "https://graph.microsoft.com/v1.0/reports/getM365AppUserDetail";
 
     protected override void PopulateReportSpecificMetadata(AppPlatformUserActivityLog dateRequestedLog, AppPlatformUserActivityDetail reportPage)
     {

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/GraphActivityLoader.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/GraphActivityLoader.cs
@@ -1,0 +1,28 @@
+﻿using ActivityImporter.Engine.Graph.O365UsageReports.Models;
+using Microsoft.Extensions.Logging;
+
+namespace ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders;
+
+public class GraphActivityLoader : IUserActivityLoader
+{
+    private readonly ManualGraphCallClient _client;
+    private readonly ILogger _logger;
+
+    public GraphActivityLoader(ManualGraphCallClient client, ILogger logger)
+    {
+        _client = client;
+        _logger = logger;
+    }
+
+    public async Task<List<TAbstractActivityRecord>> LoadReport<TAbstractActivityRecord>(DateTime dt, string reportGraphURL) where TAbstractActivityRecord : AbstractActivityRecord
+    {
+        // Load report
+        var requestUrl = $"{reportGraphURL}(date={dt.ToString("yyyy-MM-dd")})?$format=application/json";
+        _logger.LogDebug($"Loading usage from Graph {requestUrl}");
+
+        var dayReports = await _client.LoadAllPagesWithThrottleRetries<TAbstractActivityRecord>(requestUrl, _logger);
+
+        return dayReports;
+    }
+}
+

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/OneDriveUserActivityLoader.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/OneDriveUserActivityLoader.cs
@@ -9,13 +9,13 @@ namespace ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders;
 // https://docs.microsoft.com/en-us/graph/api/reportroot-getonedriveactivityuserdetail?view=graph-rest-beta
 public class OneDriveUserActivityLoader : AbstractActivityLoader<OneDriveUserActivityLog, OneDriveUserActivityRecord>
 {
-    public OneDriveUserActivityLoader(ManualGraphCallClient client, ILogger logger)
-        : base(client, logger)
+    public OneDriveUserActivityLoader(IUserActivityLoader activityLoader, IUsageReportPersistence usageReportPersistence, ILogger logger)
+        : base(activityLoader, usageReportPersistence, logger)
     {
     }
 
     public override string ReportGraphURL => "https://graph.microsoft.com/beta/reports/getOneDriveActivityUserDetail";
-    protected override void PopulateReportSpecificMetadata(OneDriveUserActivityLog todaysLog, OneDriveUserActivityRecord userActivityReportPage)
+    public override void PopulateReportSpecificMetadata(OneDriveUserActivityLog todaysLog, OneDriveUserActivityRecord userActivityReportPage)
     {
         todaysLog.SharedInternally = userActivityReportPage.SharedInternally;
         todaysLog.SharedExternally = userActivityReportPage.SharedExternally;

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/OneDriveUserActivityLoader.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/OneDriveUserActivityLoader.cs
@@ -21,7 +21,6 @@ public class OneDriveUserActivityLoader : AbstractActivityLoader<OneDriveUserAct
         todaysLog.SharedExternally = userActivityReportPage.SharedExternally;
         todaysLog.Synced = userActivityReportPage.Synced;
         todaysLog.ViewedOrEdited = userActivityReportPage.ViewedOrEdited;
-        todaysLog.LastActivityDate = userActivityReportPage.LastActivityDate;
     }
 
     protected override long CountActivity(OneDriveUserActivityRecord activityPage)
@@ -40,5 +39,5 @@ public class OneDriveUserActivityLoader : AbstractActivityLoader<OneDriveUserAct
 
         return count;
     }
-    public override DbSet<OneDriveUserActivityLog> GetTable(DataContext context) => context.OneDriveUserActivityLogs;
+    public override string DataContextPropertyName => nameof(DataContext.OneDriveUserActivityLogs);
 }

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/OneDriveUserActivityLoader.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/OneDriveUserActivityLoader.cs
@@ -4,17 +4,18 @@ using Entities.DB.Entities.UsageReports;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
-namespace ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders.ActivityLoaders;
+namespace ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders;
 
 // https://docs.microsoft.com/en-us/graph/api/reportroot-getonedriveactivityuserdetail?view=graph-rest-beta
-public class SharePointUserActivityLoader : AbstractActivityLoader<SharePointUserActivityLog, SharePointUserActivityRecord>
+public class OneDriveUserActivityLoader : AbstractActivityLoader<OneDriveUserActivityLog, OneDriveUserActivityRecord>
 {
-    public SharePointUserActivityLoader(ManualGraphCallClient client, ILogger logger)
+    public OneDriveUserActivityLoader(ManualGraphCallClient client, ILogger logger)
         : base(client, logger)
     {
     }
 
-    protected override void PopulateReportSpecificMetadata(SharePointUserActivityLog todaysLog, SharePointUserActivityRecord userActivityReportPage)
+    public override string ReportGraphURL => "https://graph.microsoft.com/beta/reports/getOneDriveActivityUserDetail";
+    protected override void PopulateReportSpecificMetadata(OneDriveUserActivityLog todaysLog, OneDriveUserActivityRecord userActivityReportPage)
     {
         todaysLog.SharedInternally = userActivityReportPage.SharedInternally;
         todaysLog.SharedExternally = userActivityReportPage.SharedExternally;
@@ -23,7 +24,7 @@ public class SharePointUserActivityLoader : AbstractActivityLoader<SharePointUse
         todaysLog.LastActivityDate = userActivityReportPage.LastActivityDate;
     }
 
-    protected override long CountActivity(SharePointUserActivityRecord activityPage)
+    protected override long CountActivity(OneDriveUserActivityRecord activityPage)
     {
         if (activityPage is null)
         {
@@ -39,7 +40,5 @@ public class SharePointUserActivityLoader : AbstractActivityLoader<SharePointUse
 
         return count;
     }
-    public override string ReportGraphURL => "https://graph.microsoft.com/beta/reports/getSharePointActivityUserDetail";
-
-    public override DbSet<SharePointUserActivityLog> GetTable(DataContext context) => context.SharePointUserActivityLogs;
+    public override DbSet<OneDriveUserActivityLog> GetTable(DataContext context) => context.OneDriveUserActivityLogs;
 }

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/OutlookUserActivityLoader.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/OutlookUserActivityLoader.cs
@@ -41,6 +41,6 @@ public class OutlookUserActivityLoader : AbstractActivityLoader<OutlookUsageActi
 
         return count;
     }
-    public override DbSet<OutlookUsageActivityLog> GetTable(DataContext context) => context.OutlookUsageActivityLogs;
+    public override string DataContextPropertyName => nameof(DataContext.OutlookUsageActivityLogs);
 
 }

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/OutlookUserActivityLoader.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/OutlookUserActivityLoader.cs
@@ -8,14 +8,14 @@ namespace ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders;
 
 public class OutlookUserActivityLoader : AbstractActivityLoader<OutlookUsageActivityLog, OutlookUserActivityUserRecord>
 {
-    public OutlookUserActivityLoader(ManualGraphCallClient client, ILogger logger)
-        : base(client, logger)
+    public OutlookUserActivityLoader(IUserActivityLoader activityLoader, IUsageReportPersistence usageReportPersistence, ILogger logger)
+        : base(activityLoader, usageReportPersistence, logger)
     {
     }
 
     public override string ReportGraphURL => "https://graph.microsoft.com/beta/reports/getEmailActivityUserDetail";
 
-    protected override void PopulateReportSpecificMetadata(OutlookUsageActivityLog todaysLog, OutlookUserActivityUserRecord userActivityReportPage)
+    public override void PopulateReportSpecificMetadata(OutlookUsageActivityLog todaysLog, OutlookUserActivityUserRecord userActivityReportPage)
     {
         todaysLog.MeetingsCreated = userActivityReportPage.MeetingCreated;
         todaysLog.ReadCount = userActivityReportPage.ReadCount;

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/OutlookUserActivityLoader.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/OutlookUserActivityLoader.cs
@@ -4,7 +4,7 @@ using Entities.DB.Entities.UsageReports;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
-namespace ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders.ActivityLoaders;
+namespace ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders;
 
 public class OutlookUserActivityLoader : AbstractActivityLoader<OutlookUsageActivityLog, OutlookUserActivityUserRecord>
 {

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/SharePointUserActivityLoader.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/SharePointUserActivityLoader.cs
@@ -1,4 +1,5 @@
-﻿using ActivityImporter.Engine.Graph.O365UsageReports.Models;
+﻿using ActivityImporter.Engine.ActivityAPI.Models;
+using ActivityImporter.Engine.Graph.O365UsageReports.Models;
 using Entities.DB;
 using Entities.DB.Entities.UsageReports;
 using Microsoft.EntityFrameworkCore;
@@ -20,7 +21,6 @@ public class SharePointUserActivityLoader : AbstractActivityLoader<SharePointUse
         todaysLog.SharedExternally = userActivityReportPage.SharedExternally;
         todaysLog.Synced = userActivityReportPage.Synced;
         todaysLog.ViewedOrEdited = userActivityReportPage.ViewedOrEdited;
-        todaysLog.LastActivityDate = userActivityReportPage.LastActivityDate;
     }
 
     protected override long CountActivity(SharePointUserActivityRecord activityPage)
@@ -41,5 +41,6 @@ public class SharePointUserActivityLoader : AbstractActivityLoader<SharePointUse
     }
     public override string ReportGraphURL => "https://graph.microsoft.com/beta/reports/getSharePointActivityUserDetail";
 
-    public override DbSet<SharePointUserActivityLog> GetTable(DataContext context) => context.SharePointUserActivityLogs;
+    public override string DataContextPropertyName => nameof(DataContext.SharePointUserActivityLogs);
+
 }

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/SharePointUserActivityLoader.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/SharePointUserActivityLoader.cs
@@ -4,18 +4,17 @@ using Entities.DB.Entities.UsageReports;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
-namespace ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders.ActivityLoaders;
+namespace ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders;
 
 // https://docs.microsoft.com/en-us/graph/api/reportroot-getonedriveactivityuserdetail?view=graph-rest-beta
-public class OneDriveUserActivityLoader : AbstractActivityLoader<OneDriveUserActivityLog, OneDriveUserActivityRecord>
+public class SharePointUserActivityLoader : AbstractActivityLoader<SharePointUserActivityLog, SharePointUserActivityRecord>
 {
-    public OneDriveUserActivityLoader(ManualGraphCallClient client, ILogger logger)
+    public SharePointUserActivityLoader(ManualGraphCallClient client, ILogger logger)
         : base(client, logger)
     {
     }
 
-    public override string ReportGraphURL => "https://graph.microsoft.com/beta/reports/getOneDriveActivityUserDetail";
-    protected override void PopulateReportSpecificMetadata(OneDriveUserActivityLog todaysLog, OneDriveUserActivityRecord userActivityReportPage)
+    protected override void PopulateReportSpecificMetadata(SharePointUserActivityLog todaysLog, SharePointUserActivityRecord userActivityReportPage)
     {
         todaysLog.SharedInternally = userActivityReportPage.SharedInternally;
         todaysLog.SharedExternally = userActivityReportPage.SharedExternally;
@@ -24,7 +23,7 @@ public class OneDriveUserActivityLoader : AbstractActivityLoader<OneDriveUserAct
         todaysLog.LastActivityDate = userActivityReportPage.LastActivityDate;
     }
 
-    protected override long CountActivity(OneDriveUserActivityRecord activityPage)
+    protected override long CountActivity(SharePointUserActivityRecord activityPage)
     {
         if (activityPage is null)
         {
@@ -40,5 +39,7 @@ public class OneDriveUserActivityLoader : AbstractActivityLoader<OneDriveUserAct
 
         return count;
     }
-    public override DbSet<OneDriveUserActivityLog> GetTable(DataContext context) => context.OneDriveUserActivityLogs;
+    public override string ReportGraphURL => "https://graph.microsoft.com/beta/reports/getSharePointActivityUserDetail";
+
+    public override DbSet<SharePointUserActivityLog> GetTable(DataContext context) => context.SharePointUserActivityLogs;
 }

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/SharePointUserActivityLoader.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/SharePointUserActivityLoader.cs
@@ -9,12 +9,12 @@ namespace ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders;
 // https://docs.microsoft.com/en-us/graph/api/reportroot-getonedriveactivityuserdetail?view=graph-rest-beta
 public class SharePointUserActivityLoader : AbstractActivityLoader<SharePointUserActivityLog, SharePointUserActivityRecord>
 {
-    public SharePointUserActivityLoader(ManualGraphCallClient client, ILogger logger)
-        : base(client, logger)
+    public SharePointUserActivityLoader(IUserActivityLoader activityLoader, IUsageReportPersistence usageReportPersistence, ILogger logger)
+        : base(activityLoader, usageReportPersistence, logger)
     {
     }
 
-    protected override void PopulateReportSpecificMetadata(SharePointUserActivityLog todaysLog, SharePointUserActivityRecord userActivityReportPage)
+    public override void PopulateReportSpecificMetadata(SharePointUserActivityLog todaysLog, SharePointUserActivityRecord userActivityReportPage)
     {
         todaysLog.SharedInternally = userActivityReportPage.SharedInternally;
         todaysLog.SharedExternally = userActivityReportPage.SharedExternally;

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/TeamsUserDeviceLoader.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/TeamsUserDeviceLoader.cs
@@ -1,7 +1,6 @@
 ﻿using ActivityImporter.Engine.Graph.O365UsageReports.Models;
 using Entities.DB;
 using Entities.DB.Entities.UsageReports;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
 namespace ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders;

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/TeamsUserDeviceLoader.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/TeamsUserDeviceLoader.cs
@@ -12,14 +12,14 @@ namespace ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders;
 /// </summary>
 public class TeamsUserDeviceLoader : AbstractActivityLoader<GlobalTeamsUserDeviceUsageLog, TeamsDeviceUsageUserDetail>
 {
-    public TeamsUserDeviceLoader(ManualGraphCallClient client, ILogger telemetry)
-        : base(client, telemetry)
+    public TeamsUserDeviceLoader(IUserActivityLoader activityLoader, IUsageReportPersistence usageReportPersistence, ILogger telemetry)
+        : base(activityLoader, usageReportPersistence, telemetry)
     {
     }
 
     public override string ReportGraphURL => "https://graph.microsoft.com/beta/reports/getTeamsDeviceUsageUserDetail";
 
-    protected override void PopulateReportSpecificMetadata(GlobalTeamsUserDeviceUsageLog dateRequestedLog, TeamsDeviceUsageUserDetail reportPage)
+    public override void PopulateReportSpecificMetadata(GlobalTeamsUserDeviceUsageLog dateRequestedLog, TeamsDeviceUsageUserDetail reportPage)
     {
         dateRequestedLog.UsedAndroidPhone = reportPage.UsedAndroidPhone;
         dateRequestedLog.UsedIOS = reportPage.UsediOS;

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/TeamsUserDeviceLoader.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/TeamsUserDeviceLoader.cs
@@ -4,7 +4,7 @@ using Entities.DB.Entities.UsageReports;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
-namespace ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders.ActivityLoaders;
+namespace ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders;
 
 
 /// <summary>

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/TeamsUserDeviceLoader.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/TeamsUserDeviceLoader.cs
@@ -19,6 +19,8 @@ public class TeamsUserDeviceLoader : AbstractActivityLoader<GlobalTeamsUserDevic
 
     public override string ReportGraphURL => "https://graph.microsoft.com/beta/reports/getTeamsDeviceUsageUserDetail";
 
+    public override string DataContextPropertyName => nameof(DataContext.TeamsUserDeviceUsageLog);
+
     public override void PopulateReportSpecificMetadata(GlobalTeamsUserDeviceUsageLog dateRequestedLog, TeamsDeviceUsageUserDetail reportPage)
     {
         dateRequestedLog.UsedAndroidPhone = reportPage.UsedAndroidPhone;
@@ -50,5 +52,4 @@ public class TeamsUserDeviceLoader : AbstractActivityLoader<GlobalTeamsUserDevic
 
         return count;
     }
-    public override DbSet<GlobalTeamsUserDeviceUsageLog> GetTable(DataContext context) => context.TeamsUserDeviceUsageLog;
 }

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/TeamsUserUsageLoader.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/TeamsUserUsageLoader.cs
@@ -4,7 +4,7 @@ using Entities.DB.Entities.UsageReports;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
-namespace ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders.ActivityLoaders;
+namespace ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders;
 
 public class TeamsUserUsageLoader : AbstractActivityLoader<GlobalTeamsUserUsageLog, TeamsUserActivityUserRecord>
 {

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/TeamsUserUsageLoader.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/TeamsUserUsageLoader.cs
@@ -8,15 +8,15 @@ namespace ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders;
 
 public class TeamsUserUsageLoader : AbstractActivityLoader<GlobalTeamsUserUsageLog, TeamsUserActivityUserRecord>
 {
-    public TeamsUserUsageLoader(ManualGraphCallClient client, ILogger logger)
-        : base(client, logger)
+    public TeamsUserUsageLoader(IUserActivityLoader activityLoader, IUsageReportPersistence usageReportPersistence, ILogger logger)
+        : base(activityLoader, usageReportPersistence, logger)
     {
     }
 
     public override string ReportGraphURL => "https://graph.microsoft.com/beta/reports/getTeamsUserActivityUserDetail";
 
 
-    protected override void PopulateReportSpecificMetadata(GlobalTeamsUserUsageLog todaysLog, TeamsUserActivityUserRecord userActivityReportPage)
+    public override void PopulateReportSpecificMetadata(GlobalTeamsUserUsageLog todaysLog, TeamsUserActivityUserRecord userActivityReportPage)
     {
         // Convert serialised object to DB object
         todaysLog.CallCount = userActivityReportPage.CallCount;

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/TeamsUserUsageLoader.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/TeamsUserUsageLoader.cs
@@ -67,6 +67,6 @@ public class TeamsUserUsageLoader : AbstractActivityLoader<GlobalTeamsUserUsageL
 
         return count;
     }
+    public override string DataContextPropertyName => nameof(DataContext.TeamUserActivityLogs);
 
-    public override DbSet<GlobalTeamsUserUsageLog> GetTable(DataContext context) => context.TeamUserActivityLogs;
 }

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/Yammer.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/Yammer.cs
@@ -4,7 +4,7 @@ using Entities.DB.Entities.UsageReports;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
-namespace ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders.ActivityLoaders;
+namespace ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders;
 
 /// <summary>
 /// https://docs.microsoft.com/en-us/graph/api/reportroot-getyammeractivityuserdetail?view=graph-rest-beta

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/Yammer.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/Yammer.cs
@@ -11,11 +11,12 @@ namespace ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders;
 /// </summary>
 public class YammerUserUsageLoader : AbstractActivityLoader<YammerUserActivityLog, YammerUserActivityUserDetail>
 {
-    public YammerUserUsageLoader(ManualGraphCallClient client, ILogger telemetry)
-        : base(client, telemetry)
+    public YammerUserUsageLoader(IUserActivityLoader activityLoader, IUsageReportPersistence usageReportPersistence, ILogger telemetry)
+        : base(activityLoader, usageReportPersistence, telemetry)
     {
     }
-    protected override void PopulateReportSpecificMetadata(YammerUserActivityLog todaysLog, YammerUserActivityUserDetail userActivityReportPage)
+
+    public override void PopulateReportSpecificMetadata(YammerUserActivityLog todaysLog, YammerUserActivityUserDetail userActivityReportPage)
     {
         // Convert serialised object to DB object
         todaysLog.ReadCount = GetOptionalInt(userActivityReportPage.ReadCount);
@@ -48,11 +49,11 @@ public class YammerUserUsageLoader : AbstractActivityLoader<YammerUserActivityLo
 /// </summary>
 public class YammerDeviceUsageLoader : AbstractActivityLoader<YammerDeviceActivityLog, YammerDeviceActivityDetail>
 {
-    public YammerDeviceUsageLoader(ManualGraphCallClient client, ILogger telemetry)
-        : base(client, telemetry)
+    public YammerDeviceUsageLoader(IUserActivityLoader activityLoader, IUsageReportPersistence usageReportPersistence, ILogger telemetry)
+        : base(activityLoader, usageReportPersistence, telemetry)
     {
     }
-    protected override void PopulateReportSpecificMetadata(YammerDeviceActivityLog todaysLog, YammerDeviceActivityDetail userActivityReportPage)
+    public override void PopulateReportSpecificMetadata(YammerDeviceActivityLog todaysLog, YammerDeviceActivityDetail userActivityReportPage)
     {
         // Convert serialised object to DB object
         todaysLog.UsedWeb = userActivityReportPage.UsedWeb;

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/Yammer.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/ReportLoaders/Yammer.cs
@@ -40,7 +40,7 @@ public class YammerUserUsageLoader : AbstractActivityLoader<YammerUserActivityLo
     }
 
     public override string ReportGraphURL => "https://graph.microsoft.com/beta/reports/getYammerActivityUserDetail";
-    public override DbSet<YammerUserActivityLog> GetTable(DataContext context) => context.YammerUserActivityLogs;
+    public override string DataContextPropertyName => nameof(DataContext.YammerUserActivityLogs);
 
 }
 
@@ -83,5 +83,5 @@ public class YammerDeviceUsageLoader : AbstractActivityLoader<YammerDeviceActivi
     }
 
     public override string ReportGraphURL => "https://graph.microsoft.com/beta/reports/getYammerDeviceUsageUserDetail";
-    public override DbSet<YammerDeviceActivityLog> GetTable(DataContext context) => context.YammerDeviceActivityLogs;
+    public override string DataContextPropertyName => nameof(DataContext.YammerDeviceActivityLogs);
 }

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/SqlUsageReportPersistence.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/SqlUsageReportPersistence.cs
@@ -27,17 +27,18 @@ public class SqlUsageReportPersistence : IUsageReportPersistence
         _logger = logger;
     }
 
-    public async Task<DateTime?> GetLastActivityForAllUsers<TReportDbType, TAbstractActivityRecord>(AbstractActivityLoader<TReportDbType, TAbstractActivityRecord> loader)
+    public async Task<DateTime?> GetOldestActivityDateForAllUsers<TReportDbType, TAbstractActivityRecord>(AbstractActivityLoader<TReportDbType, TAbstractActivityRecord> loader)
         where TReportDbType : AbstractUsageActivityLog, new()
         where TAbstractActivityRecord : AbstractActivityRecord
     {
         var table = GetReportDbTypes(loader);
-        var latest = await table.OrderByDescending(r=> r.DateOfActivity).Take(1).ToListAsync();
-        if (latest.Count() == 0)
+        var oldest = await table.OrderBy(r=> r.DateOfActivity).Take(1).ToListAsync();
+        if (oldest.Count() == 0)
         {
             return null;
         }
-        return latest.First().DateOfActivity;
+
+        return oldest.First().DateOfActivity;
     }
 
     DbSet<TReportDbType> GetReportDbTypes<TReportDbType, TAbstractActivityRecord>(AbstractActivityLoader<TReportDbType, TAbstractActivityRecord> loader)

--- a/src/ActivityImporter.Engine/Graph/O365UsageReports/SqlUsageReportPersistence.cs
+++ b/src/ActivityImporter.Engine/Graph/O365UsageReports/SqlUsageReportPersistence.cs
@@ -1,0 +1,122 @@
+﻿using Common.DataUtils;
+using Entities.DB.LookupCaches.Discrete;
+using Entities.DB;
+using Entities.DB.Entities;
+using ActivityImporter.Engine.Graph.O365UsageReports.Models;
+using ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace ActivityImporter.Engine.Graph.O365UsageReports;
+
+public class SqlUsageReportPersistence : IUsageReportPersistence
+{
+    private readonly ConcurrentLookupDbIdsCache _userEmailToDbIdCache;
+    private readonly DataContext _db;
+    private readonly UserCache _userCache;
+    private readonly ILogger _logger;
+
+    public SqlUsageReportPersistence(ConcurrentLookupDbIdsCache userEmailToDbIdCache, DataContext db, UserCache userCache, ILogger logger)
+    {
+        _userEmailToDbIdCache = userEmailToDbIdCache;
+        _db = db;
+        _userCache = userCache;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Save to SQL. Needs a shared ConcurrentLookupDbIdsCache if running in parallel with other imports.
+    /// </summary>
+    public async Task SaveLoadedReports<TReportDbType, TAbstractActivityRecord>(Dictionary<DateTime, List<TAbstractActivityRecord>> LoadedReportPages,
+        AbstractActivityLoader<TReportDbType, TAbstractActivityRecord> loader)
+            where TReportDbType : AbstractUsageActivityLog, new()
+            where TAbstractActivityRecord : AbstractActivityRecord
+    {
+        int i = 0; var enUS = new System.Globalization.CultureInfo("en-US");
+        var allInserts = new List<TReportDbType>();
+        // For each day in dataset (Key)
+        foreach (var dateTime in LoadedReportPages.Keys)
+        {
+            // Pre-cache all reports on that date
+            _logger.LogDebug($"Saving {typeof(TReportDbType).Name} for date {dateTime.ToString("dd-MM-yyyy")}");
+            var allReportsOnDate = await loader.GetTable(_db).Where(t =>
+                                            t.Date.Year == dateTime.Year &&
+                                            t.Date.Month == dateTime.Month &&
+                                            t.Date.Day == dateTime.Day
+                                        ).ToListAsync();
+
+            // Look through Graph results & compare with already saved reports for this date
+            foreach (var reportPage in LoadedReportPages[dateTime])
+            {
+                // Do we have a cached ID for the lookup?
+                int? lookupId = null;
+                lookupId = _userEmailToDbIdCache.GetCachedIdForName<TReportDbType>(reportPage.LookupFieldValue);
+
+                if (lookupId == null)
+                {
+                    // See if there's already a log defined for this date + lookup (usually "user")
+                    var lookup = await reportPage.GetOrCreateLookup(_userCache);
+
+                    // Sanity
+                    if (!lookup.IsSavedToDB)
+                    {
+                        throw new InvalidOperationException("Cannot use unsaved lookups for activity records");
+                    }
+
+                    // Cache lookup
+                    lookupId = lookup.ID;
+                    _userEmailToDbIdCache.AddOrUpdateForName<TReportDbType>(reportPage.LookupFieldValue, lookupId.Value);
+                }
+
+
+                var dateRequestedLog = allReportsOnDate.FirstOrDefault(t =>
+                        t.AssociatedLookupId == lookupId.Value
+                    );
+
+                // Output progress every 1000 imports
+                if (i > 0 && i % 1000 == 0)
+                {
+                    Console.WriteLine($"{GetType().Name}: Saved {i} / {LoadedReportPages.SelectMany(r => r.Value).Count()}");
+                }
+
+                // Create new log if necesary
+                if (dateRequestedLog == null)
+                {
+                    dateRequestedLog = new TReportDbType()
+                    {
+                        AssociatedLookupId = lookupId.Value   // date set below
+                    };
+
+                    // Add new logs to list to insert
+                    allInserts.Add(dateRequestedLog);
+                }
+
+                // Set log stats
+                dateRequestedLog.Date = dateTime.Date;
+
+                // Example: "2017-08-30"
+                var activityDate = DateTime.MinValue;
+                if (!string.IsNullOrEmpty(reportPage.LastActivityDateString))
+                {
+                    if (DateTime.TryParseExact(reportPage.LastActivityDateString, "yyyy-MM-dd", enUS, System.Globalization.DateTimeStyles.None, out activityDate))
+                    {
+                        dateRequestedLog.LastActivityDate = activityDate;
+                    }
+                    else
+                    {
+                        _logger.LogWarning($"Invalid LastActivity value: '{reportPage.LastActivityDateString}'");
+                        dateRequestedLog.LastActivityDate = null;
+                    }
+                }
+                loader.PopulateReportSpecificMetadata(dateRequestedLog, reportPage);
+
+                i++;
+            }
+        }
+
+        // All inserts at once
+        loader.GetTable(_db).AddRange(allInserts);
+
+        await _db.SaveChangesAsync();
+    }
+}

--- a/src/ActivityImporter.Engine/Graph/PageableGraphLoaderExtensions.cs
+++ b/src/ActivityImporter.Engine/Graph/PageableGraphLoaderExtensions.cs
@@ -1,84 +1,82 @@
 ﻿using Microsoft.Extensions.Logging;
 
-namespace ActivityImporter.Engine.Graph
+namespace ActivityImporter.Engine.Graph;
+
+public static class PageableGraphLoaderExtensions
 {
-    public static class PageableGraphLoaderExtensions
+    public static async Task<List<T>> LoadAllPagesWithThrottleRetries<T>(this ManualGraphCallClient client, string url, ILogger debugTracer)
     {
-        public static async Task<List<T>> LoadAllPagesWithThrottleRetries<T>(this ManualGraphCallClient client, string url, ILogger debugTracer)
+        var results = await LoadPageableGraphResponseAllWithOptionalDelta<T>(client, url, debugTracer, null);
+
+        return results;
+    }
+
+    public static async Task<List<T>> LoadAllPagesPlusDeltaWithThrottleRetries<T>(this ManualGraphCallClient client, string url, ILogger debugTracer, Func<string, Task> deltaTokenFunc)
+    {
+        var results = await LoadPageableGraphResponseAllWithOptionalDelta<T>(client, url, debugTracer, deltaTokenFunc);
+
+        return results;
+    }
+
+    static async Task<List<T>> LoadPageableGraphResponseAllWithOptionalDelta<T>(ManualGraphCallClient client, string url, ILogger debugTracer, Func<string, Task>? deltaTokenFunc)
+    {
+        var allResults = new List<T>();
+
+        int pageCount = 1;
+
+        // Loop until no pages left
+        string? nextUrl = url;
+        while (!string.IsNullOrEmpty(nextUrl))
         {
-            var results = await LoadPageableGraphResponseAllWithOptionalDelta<T>(client, url, debugTracer, null);
-
-            return results;
-        }
-
-        public static async Task<List<T>> LoadAllPagesPlusDeltaWithThrottleRetries<T>(this ManualGraphCallClient client, string url, ILogger debugTracer, Func<string, Task> deltaTokenFunc)
-        {
-            var results = await LoadPageableGraphResponseAllWithOptionalDelta<T>(client, url, debugTracer, deltaTokenFunc);
-
-            return results;
-        }
-
-        static async Task<List<T>> LoadPageableGraphResponseAllWithOptionalDelta<T>(ManualGraphCallClient client, string url, ILogger debugTracer, Func<string, Task>? deltaTokenFunc)
-        {
-            var allResults = new List<T>();
-
-            int pageCount = 1;
-
-            // Loop until no pages left
-            string? nextUrl = url;
-            while (!string.IsNullOrEmpty(nextUrl))
+            var pageSuccess = false;
+            PageableGraphResponseWithDelta<T>? queryResult = null;
+            try
             {
-                var pageSuccess = false;
-                PageableGraphResponseWithDelta<T>? queryResult = null;
-                try
-                {
-                    queryResult = await client.GetAsyncWithThrottleRetries<PageableGraphResponseWithDelta<T>>(nextUrl);
-                    pageSuccess = true;
-                }
-                catch (HttpRequestException ex)
-                {
-                    pageSuccess = false;
-                    debugTracer.LogError($"Got unexpected HTTP exception on page {pageCount}: {ex.Message}.");
+                queryResult = await client.GetAsyncWithThrottleRetries<PageableGraphResponseWithDelta<T>>(nextUrl);
+                pageSuccess = true;
+            }
+            catch (HttpRequestException ex)
+            {
+                pageSuccess = false;
+                debugTracer.LogError($"Got unexpected HTTP exception on page {pageCount}: {ex.Message}.");
 
-                    // Transient error?
-                    if (ex.Message != null && ex.Message.ToLower().Contains("gateway timeout"))
-                    {
-                        debugTracer.LogWarning($"Got gateway timeout. Will retry page.");
-                        await Task.Delay(1000);
-                    }
-                    else
-                    {
-                        debugTracer.LogWarning($"Unexpected HTTP error. Will not retry page & returning results upto current page.");
-                        nextUrl = null;
-                    }
-                }
-
-                if (pageSuccess)
+                // Transient error?
+                if (ex.Message != null && ex.Message.ToLower().Contains("gateway timeout"))
                 {
-                    // Another page?
-                    nextUrl = queryResult?.OdataNextLink;
-                    if (nextUrl != null)
-                    {
-                        pageCount++;
-                        debugTracer.LogInformation($"Loading {typeof(T).Name} results page #{pageCount}...");
-                    }
-                    else
-                    {
-                        // Last page of results. Do we have a delta link?
-                        if (!string.IsNullOrEmpty(queryResult?.DeltaLink) && deltaTokenFunc != null)
-                        {
-                            await deltaTokenFunc(queryResult.DeltaLink);
-                        }
-                    }
-                    if (queryResult?.PageResults != null)
-                    {
-                        allResults.AddRange(queryResult.PageResults);
-                    }
+                    debugTracer.LogWarning($"Got gateway timeout. Will retry page.");
+                    await Task.Delay(1000);
+                }
+                else
+                {
+                    debugTracer.LogWarning($"Unexpected HTTP error. Will not retry page & returning results upto current page.");
+                    nextUrl = null;
                 }
             }
 
-            return allResults;
+            if (pageSuccess)
+            {
+                // Another page?
+                nextUrl = queryResult?.OdataNextLink;
+                if (nextUrl != null)
+                {
+                    pageCount++;
+                    debugTracer.LogInformation($"Loading {typeof(T).Name} results page #{pageCount}...");
+                }
+                else
+                {
+                    // Last page of results. Do we have a delta link?
+                    if (!string.IsNullOrEmpty(queryResult?.DeltaLink) && deltaTokenFunc != null)
+                    {
+                        await deltaTokenFunc(queryResult.DeltaLink);
+                    }
+                }
+                if (queryResult?.PageResults != null)
+                {
+                    allResults.AddRange(queryResult.PageResults);
+                }
+            }
         }
-    }
 
+        return allResults;
+    }
 }

--- a/src/ActivityImporter.Engine/Graph/PageableGraphResponse.cs
+++ b/src/ActivityImporter.Engine/Graph/PageableGraphResponse.cs
@@ -1,28 +1,26 @@
 ﻿using Newtonsoft.Json;
 
-namespace ActivityImporter.Engine.Graph
+namespace ActivityImporter.Engine.Graph;
+
+public class PageableGraphResponse<T>
 {
-    public class PageableGraphResponse<T>
+    public PageableGraphResponse()
     {
-        public PageableGraphResponse()
-        {
-        }
-        public PageableGraphResponse(IEnumerable<T> results)
-        {
-            PageResults.AddRange(results);
-        }
-
-        [JsonProperty("@odata.nextLink")]
-        public string OdataNextLink { get; set; } = null!;
-
-        [JsonProperty("value")]
-        public List<T> PageResults { get; set; } = new List<T>();
+    }
+    public PageableGraphResponse(IEnumerable<T> results)
+    {
+        PageResults.AddRange(results);
     }
 
-    public class PageableGraphResponseWithDelta<T> : PageableGraphResponse<T>
-    {
-        [JsonProperty("@odata.deltaLink")]
-        public string DeltaLink { get; set; } = null!;
-    }
+    [JsonProperty("@odata.nextLink")]
+    public string OdataNextLink { get; set; } = null!;
 
+    [JsonProperty("value")]
+    public List<T> PageResults { get; set; } = new List<T>();
+}
+
+public class PageableGraphResponseWithDelta<T> : PageableGraphResponse<T>
+{
+    [JsonProperty("@odata.deltaLink")]
+    public string DeltaLink { get; set; } = null!;
 }

--- a/src/Common.DataUtils/CommonStringUtils.cs
+++ b/src/Common.DataUtils/CommonStringUtils.cs
@@ -1,4 +1,6 @@
-﻿namespace Common.DataUtils;
+﻿using System.Globalization;
+
+namespace Common.DataUtils;
 
 public static class CommonStringUtils
 {
@@ -55,6 +57,19 @@ public static class CommonStringUtils
     public static string ToGraphDateString(this DateTime dateTime)
     {
         return dateTime.ToString("yyyy-MM-dd");
+    }
+
+    public static DateTime? FromGraphDateString(string s)
+    {
+        DateTime dt;
+        if (DateTime.TryParseExact(s, "dd-MM-yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None, out dt))
+        {
+            return dt;
+        }
+        else
+        {
+            return null;
+        }
     }
 
     public static string EnsureMaxLength(string? potentiallyLongString, int maxLength)

--- a/src/Common.DataUtils/CommonStringUtils.cs
+++ b/src/Common.DataUtils/CommonStringUtils.cs
@@ -52,6 +52,11 @@ public static class CommonStringUtils
 
     }
 
+    public static string ToGraphDateString(this DateTime dateTime)
+    {
+        return dateTime.ToString("yyyy-MM-dd");
+    }
+
     public static string EnsureMaxLength(string? potentiallyLongString, int maxLength)
     {
         if (string.IsNullOrEmpty(potentiallyLongString))

--- a/src/Entities.DB/DbInitialiser.cs
+++ b/src/Entities.DB/DbInitialiser.cs
@@ -62,7 +62,7 @@ public class DbInitialiser
                 // Add some base survey pages
                 AddTestSurveyPages(context);
 #if DEBUG
-                DirtyTestDataHackInserts(context, logger, editDoc, getHighlights);
+                await DirtyTestDataHackInserts(context, logger, editDoc, getHighlights);
                 await context.SaveChangesAsync();
 
                 await FakeDataGen.GenerateFakeCopilotFor(defaultUserUPN, context, logger);

--- a/src/Entities.DB/Entities/BaseActivityClasses.cs
+++ b/src/Entities.DB/Entities/BaseActivityClasses.cs
@@ -8,17 +8,14 @@ namespace Entities.DB.Entities;
 public abstract class AbstractUsageActivityLog : UserRelatedEntity
 {
     [Column("date")]
-    public DateTime Date { get; set; }
-
-    [Column("last_activity_date")]
-    public DateTime? LastActivityDate { get; set; }
+    public DateTime DateOfActivity { get; set; }
 
     [NotMapped]
     public abstract int AssociatedLookupId { get; set; }
 
     public override string ToString()
     {
-        return $"{GetType().Name} - {Date}";
+        return $"{GetType().Name} - {DateOfActivity}";
     }
 }
 

--- a/src/Entities.DB/Entities/License.cs
+++ b/src/Entities.DB/Entities/License.cs
@@ -10,13 +10,13 @@ public class UserLicenseTypeLookup : AbstractEFEntity
     [Column("user_id")]
     public int UserId { get; set; }
 
-    public User User { get; set; }
+    public User User { get; set; } = null!;
 
     [ForeignKey(nameof(License))]
     [Column("license_type_id")]
     public int LicenseTypeId { get; set; }
 
-    public LicenseType License { get; set; }
+    public LicenseType License { get; set; } = null!;
 
 }
 
@@ -24,5 +24,5 @@ public class UserLicenseTypeLookup : AbstractEFEntity
 public class LicenseType : AbstractEFEntityWithName
 {
     [Column("sku_id")]
-    public string SKUID { get; set; }
+    public string SKUID { get; set; } = null!;
 }

--- a/src/Entities.DB/FakeDataGen.cs
+++ b/src/Entities.DB/FakeDataGen.cs
@@ -86,8 +86,7 @@ public class FakeDataGen
         context.OutlookUsageActivityLogs.Add(new Entities.UsageReports.OutlookUsageActivityLog
         {
             User = user,
-            Date = DateTime.Now,
-            LastActivityDate = DateTime.Now,
+            DateOfActivity = DateTime.Now,
             MeetingsCreated = 1,
             MeetingsInteracted = 1,
             ReadCount = 1,
@@ -97,8 +96,7 @@ public class FakeDataGen
         context.AppPlatformUserUsageLog.Add(new Entities.UsageReports.AppPlatformUserActivityLog
         {
             User = user,
-            LastActivityDate = DateTime.Now,
-            Date = DateTime.Now,
+            DateOfActivity = DateTime.Now,
             Excel = true,
             ExcelMobile= true,
             ExcelWindows = true,
@@ -136,9 +134,8 @@ public class FakeDataGen
         });
 
         context.SharePointUserActivityLogs.Add(new Entities.UsageReports.SharePointUserActivityLog {
-            Date = DateTime.Now,
+            DateOfActivity = DateTime.Now,
             User = user,
-            LastActivityDate = DateTime.Now,
 
             SharedExternally = 1,
             SharedInternally = 1,
@@ -148,9 +145,8 @@ public class FakeDataGen
 
         context.OneDriveUserActivityLogs.Add(new Entities.UsageReports.OneDriveUserActivityLog
         {
-            Date = DateTime.Now,
+            DateOfActivity = DateTime.Now,
             User = user,
-            LastActivityDate = DateTime.Now,
             SharedExternally = 1,
             SharedInternally = 1,
             Synced = 1,
@@ -159,9 +155,8 @@ public class FakeDataGen
 
         context.YammerUserActivityLogs.Add(new Entities.UsageReports.YammerUserActivityLog
         {
-            Date = DateTime.Now,
+            DateOfActivity = DateTime.Now,
             User = user,
-            LastActivityDate = DateTime.Now,
             LikedCount = 1,
             PostedCount = 1,
             ReadCount = 1,
@@ -169,9 +164,8 @@ public class FakeDataGen
 
         context.YammerDeviceActivityLogs.Add(new Entities.UsageReports.YammerDeviceActivityLog
         {
-            Date = DateTime.Now,
+            DateOfActivity = DateTime.Now,
             User = user,
-            LastActivityDate = DateTime.Now,
             UsedAndroidPhone = true,
             UsedIpad = true,
             UsedIphone = true,
@@ -182,9 +176,8 @@ public class FakeDataGen
 
         context.TeamUserActivityLogs.Add(new Entities.UsageReports.GlobalTeamsUserUsageLog
         {
-            Date = DateTime.Now,
+            DateOfActivity = DateTime.Now,
             User = user,
-            LastActivityDate = DateTime.Now,
             AdHocMeetingsAttendedCount = 1,
             AdHocMeetingsOrganizedCount = 1,
             CallCount = 1,
@@ -207,9 +200,8 @@ public class FakeDataGen
 
         context.TeamsUserDeviceUsageLog.Add(new Entities.UsageReports.GlobalTeamsUserDeviceUsageLog
         {
-            Date = DateTime.Now,
+            DateOfActivity = DateTime.Now,
             User = user,
-            LastActivityDate = DateTime.Now,
             UsedAndroidPhone = true,
             UsedChromeOS = true,
             UsedIOS = true,

--- a/src/Entities.DB/LookupCaches/Discrete/LicenseTypeCache.cs
+++ b/src/Entities.DB/LookupCaches/Discrete/LicenseTypeCache.cs
@@ -9,7 +9,7 @@ public class LicenseTypeCache : DBLookupCache<LicenseType>
 
     public override DbSet<LicenseType> EntityStore => this.DB.LicenseTypes;
 
-    public async override Task<LicenseType> Load(string searchName)
+    public async override Task<LicenseType?> Load(string searchName)
     {
         return await EntityStore.SingleOrDefaultAsync(t => t.Name == searchName);
     }

--- a/src/Entities.DB/LookupCaches/Discrete/StateOrProvinceCache.cs
+++ b/src/Entities.DB/LookupCaches/Discrete/StateOrProvinceCache.cs
@@ -10,7 +10,7 @@ public class StateOrProvinceCache : DBLookupCache<StateOrProvince>
 
     public override DbSet<StateOrProvince> EntityStore => this.DB.StateOrProvinces;
 
-    public async override Task<StateOrProvince> Load(string searchName)
+    public async override Task<StateOrProvince?> Load(string searchName)
     {
         return await EntityStore.SingleOrDefaultAsync(t => t.Name == searchName);
     }

--- a/src/UnitTests/FakeLoaderClasses/FakeUserActivityClasses.cs
+++ b/src/UnitTests/FakeLoaderClasses/FakeUserActivityClasses.cs
@@ -8,17 +8,21 @@ namespace UnitTests.FakeLoaderClasses;
 
 public class FakeUserActivityLoader : IUserActivityLoader
 {
+    public int ResultsPerPage { get; set; } = 1;
     public Task<List<TAbstractActivityRecord>> LoadReport<TAbstractActivityRecord>(DateTime dt, string reportGraphURL) 
         where TAbstractActivityRecord : AbstractActivityRecord
     {
-        var datoir = new List<TeamsDeviceUsageUserDetail>
+        var datoir = new List<TeamsDeviceUsageUserDetail>();
+        for (int i = 0; i < ResultsPerPage; i++)
         {
-            new TeamsDeviceUsageUserDetail
+            datoir.Add(new TeamsDeviceUsageUserDetail
             {
-                LastActivityDateString = DateTime.UtcNow.AddDays(-1).ToGraphDateString(),
-                UserPrincipalName = "user@org.local"
-            }
-        };
+                LastActivityDateString = DateTime.UtcNow.AddDays(i * -1).ToGraphDateString(),
+                UserPrincipalName = "user@org.local",
+                UsedAndroidPhone = false,
+                // etc
+            });
+        }
 
         return Task.FromResult(datoir.Cast<TAbstractActivityRecord>().ToList());
     }
@@ -26,7 +30,7 @@ public class FakeUserActivityLoader : IUserActivityLoader
 
 public class FakeUsageReportPersistence : IUsageReportPersistence
 {
-    public Task<DateTime?> GetLastActivity<TReportDbType, TAbstractActivityRecord>(AbstractActivityLoader<TReportDbType, TAbstractActivityRecord> loader, string forUPN)
+    public Task<DateTime?> GetLastActivityForAllUsers<TReportDbType, TAbstractActivityRecord>(AbstractActivityLoader<TReportDbType, TAbstractActivityRecord> loader)
         where TReportDbType : AbstractUsageActivityLog, new()
         where TAbstractActivityRecord : AbstractActivityRecord
     {

--- a/src/UnitTests/FakeLoaderClasses/FakeUserActivityClasses.cs
+++ b/src/UnitTests/FakeLoaderClasses/FakeUserActivityClasses.cs
@@ -30,7 +30,7 @@ public class FakeUserActivityLoader : IUserActivityLoader
 
 public class FakeUsageReportPersistence : IUsageReportPersistence
 {
-    public Task<DateTime?> GetLastActivityForAllUsers<TReportDbType, TAbstractActivityRecord>(AbstractActivityLoader<TReportDbType, TAbstractActivityRecord> loader)
+    public Task<DateTime?> GetOldestActivityDateForAllUsers<TReportDbType, TAbstractActivityRecord>(AbstractActivityLoader<TReportDbType, TAbstractActivityRecord> loader)
         where TReportDbType : AbstractUsageActivityLog, new()
         where TAbstractActivityRecord : AbstractActivityRecord
     {

--- a/src/UnitTests/FakeLoaderClasses/FakeUserActivityClasses.cs
+++ b/src/UnitTests/FakeLoaderClasses/FakeUserActivityClasses.cs
@@ -1,0 +1,35 @@
+﻿using ActivityImporter.Engine.Graph.O365UsageReports;
+using ActivityImporter.Engine.Graph.O365UsageReports.Models;
+using ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders;
+using Common.DataUtils;
+using Entities.DB.Entities;
+
+namespace UnitTests.FakeLoaderClasses;
+
+public class FakeUserActivityLoader : IUserActivityLoader
+{
+    public Task<List<TAbstractActivityRecord>> LoadReport<TAbstractActivityRecord>(DateTime dt, string reportGraphURL) 
+        where TAbstractActivityRecord : AbstractActivityRecord
+    {
+        var datoir = new List<TeamsDeviceUsageUserDetail>
+        {
+            new TeamsDeviceUsageUserDetail
+            {
+                LastActivityDateString = DateTime.UtcNow.AddDays(-1).ToGraphDateString(),
+                UserPrincipalName = "user@org.local"
+            }
+        };
+
+        return Task.FromResult(datoir.Cast<TAbstractActivityRecord>().ToList());
+    }
+}
+
+public class FakeUsageReportPersistence : IUsageReportPersistence
+{
+    public Task SaveLoadedReports<TReportDbType, TAbstractActivityRecord>(Dictionary<DateTime, List<TAbstractActivityRecord>> reportPages, AbstractActivityLoader<TReportDbType, TAbstractActivityRecord> loader)
+        where TReportDbType : AbstractUsageActivityLog, new()
+        where TAbstractActivityRecord : AbstractActivityRecord
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/UnitTests/FakeLoaderClasses/FakeUserActivityClasses.cs
+++ b/src/UnitTests/FakeLoaderClasses/FakeUserActivityClasses.cs
@@ -26,10 +26,19 @@ public class FakeUserActivityLoader : IUserActivityLoader
 
 public class FakeUsageReportPersistence : IUsageReportPersistence
 {
-    public Task SaveLoadedReports<TReportDbType, TAbstractActivityRecord>(Dictionary<DateTime, List<TAbstractActivityRecord>> reportPages, AbstractActivityLoader<TReportDbType, TAbstractActivityRecord> loader)
+    public Task<DateTime?> GetLastActivity<TReportDbType, TAbstractActivityRecord>(AbstractActivityLoader<TReportDbType, TAbstractActivityRecord> loader, string forUPN)
         where TReportDbType : AbstractUsageActivityLog, new()
         where TAbstractActivityRecord : AbstractActivityRecord
     {
         throw new NotImplementedException();
+    }
+
+    public Task SaveLoadedReports<TReportDbType, TAbstractActivityRecord>(Dictionary<DateTime, List<TAbstractActivityRecord>> reportPages, 
+        AbstractActivityLoader<TReportDbType, TAbstractActivityRecord> loader)
+        where TReportDbType : AbstractUsageActivityLog, new()
+        where TAbstractActivityRecord : AbstractActivityRecord
+    {
+        Console.WriteLine("FakeUsageReportPersistence.SaveLoadedReports");
+        return Task.CompletedTask;
     }
 }

--- a/src/UnitTests/UsageLoaderTests.cs
+++ b/src/UnitTests/UsageLoaderTests.cs
@@ -1,0 +1,19 @@
+﻿using ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders;
+using UnitTests.FakeLoaderClasses;
+
+namespace UnitTests;
+
+[TestClass]
+public class UsageLoaderTests : AbstractTest
+{
+
+    [TestMethod]
+    public async Task FakeTeamsActivity()
+    {
+        var activityLoader = new FakeUserActivityLoader();
+        var loader = new TeamsUserDeviceLoader(activityLoader, _logger);
+        await loader.PopulateLoadedReportPagesFromGraph(3);
+        Assert.AreEqual(3, loader.LoadedReportPages.Count);
+
+    }
+}

--- a/src/UnitTests/UsageLoaderTests.cs
+++ b/src/UnitTests/UsageLoaderTests.cs
@@ -11,7 +11,7 @@ public class UsageLoaderTests : AbstractTest
     public async Task FakeTeamsActivity()
     {
         var activityLoader = new FakeUserActivityLoader();
-        var loader = new TeamsUserDeviceLoader(activityLoader, _logger);
+        var loader = new TeamsUserDeviceLoader(activityLoader, new FakeUsageReportPersistence(), _logger);
         await loader.PopulateLoadedReportPagesFromGraph(3);
         Assert.AreEqual(3, loader.LoadedReportPages.Count);
 

--- a/src/UnitTests/UsageLoaderTests.cs
+++ b/src/UnitTests/UsageLoaderTests.cs
@@ -1,4 +1,5 @@
-﻿using ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders;
+﻿using ActivityImporter.Engine.Graph.O365UsageReports;
+using ActivityImporter.Engine.Graph.O365UsageReports.ReportLoaders;
 using UnitTests.FakeLoaderClasses;
 
 namespace UnitTests;
@@ -11,9 +12,9 @@ public class UsageLoaderTests : AbstractTest
     public async Task FakeTeamsActivity()
     {
         var activityLoader = new FakeUserActivityLoader();
-        var loader = new TeamsUserDeviceLoader(activityLoader, new FakeUsageReportPersistence(), _logger);
-        await loader.PopulateLoadedReportPagesFromGraph(3);
-        Assert.AreEqual(3, loader.LoadedReportPages.Count);
+        var loader = new TeamsUserDeviceLoader(activityLoader, new SqlUsageReportPersistence(_db, _logger), _logger);
+        var p = await loader.LoadAndSaveUsagePages();
+        Assert.AreEqual(3, p.Count);
 
     }
 }


### PR DESCRIPTION
Activity import now reads as far back as needed, up-to the max the API allows. If activity is found in DB, we read from the oldest entry in the DB from the API.